### PR TITLE
Updating verbiage in production assignment.

### DIFF
--- a/02_activities/assignments/assignment_1.ipynb
+++ b/02_activities/assignments/assignment_1.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Prerequisites\n",
     "\n",
-    "+ This notebook assumes that price data is available to you in the environment variable `PRICE_DATA`. If you have not done so, then execute the notebook `production_2_data_engineering.ipynb` to create this data set.\n"
+    "+ This notebook assumes that price data is available to you in the environment variable `PRICE_DATA`. If you have not done so, then execute the notebook `01_materials/labs/2_data_engineering.ipynb` to create this data set.\n"
    ]
   },
   {

--- a/03_instructional_team/markdown_slides/02_data_engineering.md
+++ b/03_instructional_team/markdown_slides/02_data_engineering.md
@@ -49,7 +49,7 @@ $ echo "Data Science Institute"
 
 **Notebooks**
 
-- `./01_materials/labs/production_2_data_engineering.ipynb`
+- `./01_materials/labs/2_data_engineering.ipynb`
 
 **Code**
 


### PR DESCRIPTION
This pull request addresses a confusion regarding the notebook reference in the assignment_1.ipynb file. Previously, students were instructed to execute a notebook named `production_2_data_engineering.ipynb` to create the dataset, but this notebook did not exist in the repository, leading to confusion.

### Changes made:
- Updated the instructions in `assignment_1.ipynb` to correctly reference `./01_materials/labs/02_data_engineering.ipynb`, which is the correct notebook to be executed for the data engineering step, as confirmed by the Technical Facilitator.

This should resolve any issues students were facing when trying to complete the assignment.